### PR TITLE
Bugfix: random word raises java.io.FileNotFoundException

### DIFF
--- a/web/WEB-INF/jspf/controller.jspf
+++ b/web/WEB-INF/jspf/controller.jspf
@@ -18,6 +18,10 @@
             case 2:
                 String redirectURL = "index.jsp?id=" + Entry.getRandom();
                 response.sendRedirect(redirectURL);
+                /* Keep this line to avoid breaking the loop:
+                   It renders the page and then performs the redirect.
+                 */
+                szAction = "WEB-INF/jspf/about.jsp";
                 break;
             case 3:
                 szAction = "WEB-INF/jspf/about.jsp";


### PR DESCRIPTION
## Steps to reproduce the issue
1. Go to diccionario homepage
2. Visit "random word" link (`index.jsp?action=2`)
3. App raises 500 error

## Traceback
```java
java.io.IOException: An exception occurred processing [index.jsp] at line [44]

41:                     <div class="grid_13">
42:                       <%@ include file="WEB-INF/jspf/search_form.jspf" %>
43:                       <div id="main-content">
44:                         <jsp:include page="<%=szAction %>" />
45:                         <%@ include file="WEB-INF/jspf/search.jspf" %>
46:                       </div>
47:                     </div>

Caused by: java.io.FileNotFoundException: The requested resource [/2] is not available

```

**Reason**: `szAction` is initialized with '2' value and this is not a jspf file

## Proposed solution
Initialize `szAction` with the path of an existing jspf file to allow render the page and after that app will **perform the redirect**.